### PR TITLE
Integrate gitlab auth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,12 @@ jobs:
     #Task for setting up Python 3.10 using actions/setup-python@v2 Github action
       - name: Set up Python
         uses: actions/setup-python@v2.3.0
+        
         with:
           python-version: "3.10"
+
+      # - uses: isort/isort-action@master
+
       - run: pip install --upgrade pip
       - run: pip install black pytest
       - run: black .

--- a/README.md
+++ b/README.md
@@ -29,14 +29,16 @@ GITHUB_ACCESS_TOKEN=`cat ~/.github_access_token`
 GITHUB_USERNAME=<your_github_username>
 GITHUB_URL=<your_github_url where the authorization code lives>
 ENVIRONMENT=<your_environment e.g. production|development>
-HOST=datasource
+HOST=datasource <production>, HOST=localhost <development>
 PORT=5432
 DB_USER=postgres
 PASSWORD=postgres
 DATABASE=datasource
 ```
 
-Run the application:
+Run the application - production mode:
+
+
 
 ```console
 $ gunicorn -w 4 -k uvicorn.workers.UvicornWorker app.server.api:app --bind 0.0.0.0:8080
@@ -56,11 +58,14 @@ Create a postgres database, called datasource <br />
     CONNECTION LIMIT = -1;
   ```
 
-Run the application entry point:
+Run the application entry point - development mode:
+
+
 
 ```console
-$ python3 main.py
+$ uvicorn app.server.api:app --port 8080 --reload
 ```
+
 
 Open [localhost:8000/docs](localhost:8000/docs) for API Documentation.
 

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     TEST_DATABASE_PATH: Optional[str] = ""
     OPAL_SERVER_DATA_URL: Optional[str] = ""
     ENVIRONMENT: Optional[str] = "production"
+    GITLAB_CLIENT_ID: Optional[str] = ""
+    GITLAB_CLIENT_SECRET: Optional[str] = ""
 
     # POSTGRES CONNECTION
     HOST: Optional[str] = ""

--- a/app/database/datasource_database.py
+++ b/app/database/datasource_database.py
@@ -56,9 +56,7 @@ class Database:
         """
         Create tables in database
         """
-
         cursor = self.connect()
-
         with open(file_path, "r", encoding="utf-8") as file:
             sql = sqlparse.split(sqlparse.format(file.read(), strip_comments=True))
         with cursor:

--- a/app/schemas/rules.py
+++ b/app/schemas/rules.py
@@ -20,7 +20,6 @@ class RequestObject(BaseModel):
                 "name": "Example",
                 "owner": "r-scheele",
                 "repo_url": "https://github.com/r-scheele/opal-policy-example",
-                # "github_repo_url": "https://gitlab.com/r-scheele/opal-policy-example",
                 "rules": [
                     [
                         {
@@ -132,7 +131,6 @@ class UpdateRequestObject(BaseModel):
                 "name": "Example",
                 "owner": "r-scheele",
                 "repo_url": "https://github.com/r-scheele/opal-policy-example",
-                # "github_repo_url": "https://gitlab.com/r-scheele/opal-policy-example",
                 "rules": [
                     [
                         {

--- a/app/schemas/rules.py
+++ b/app/schemas/rules.py
@@ -19,7 +19,8 @@ class RequestObject(BaseModel):
             "example": {
                 "name": "Example",
                 "owner": "r-scheele",
-                "github_repo_url": "https://github.com/r-scheele/opal-policy-example",
+                "repo_url": "https://github.com/r-scheele/opal-policy-example",
+                # "github_repo_url": "https://gitlab.com/r-scheele/opal-policy-example",
                 "rules": [
                     [
                         {
@@ -130,7 +131,8 @@ class UpdateRequestObject(BaseModel):
             "example": {
                 "name": "Example",
                 "owner": "r-scheele",
-                "github_repo_url": "https://github.com/r-scheele/opal-policy-example",
+                "repo_url": "https://github.com/r-scheele/opal-policy-example",
+                # "github_repo_url": "https://gitlab.com/r-scheele/opal-policy-example",
                 "rules": [
                     [
                         {

--- a/app/server/auth/authenticate.py
+++ b/app/server/auth/authenticate.py
@@ -12,27 +12,10 @@ router = APIRouter()
 from app.config.config import settings
 
 
-# @router.get("/github/login")
-# async def login_github():
-#     APP_ID, REDIRECT_URI = (settings.GITHUB_CLIENT_ID, "http://localhost:8080/token")
-#     url = f"https://github.com/login/oauth/authorize?client_id={APP_ID}&redirect_uri={REDIRECT_URI}&response_type=code"
-#     return RedirectResponse(url=url)
-
-
-# @router.get("/gitlab/login")
-# async def login_gitlab():
-#     APP_ID, REDIRECT_URI = (
-#         settings.GITLAB_CLIENT_ID,
-#         "http://localhost:8080/api/auth/callback/gitlab",
-#     )
-#     url = f"https://gitlab.com/oauth/authorize?client_id={APP_ID}&redirect_uri={REDIRECT_URI}&response_type=code"
-#     return RedirectResponse(url=url)
-
-
 @router.get("/api/auth/callback/gitlab")
 async def get_token_from_gitlab(
     code: str, client_id: str, client_secret: str, redirect_uri: str
-):
+) -> dict:
     res = rest_client.post(
         f"https://gitlab.com/oauth/token",
         data={

--- a/app/server/auth/authenticate.py
+++ b/app/server/auth/authenticate.py
@@ -19,32 +19,32 @@ from app.config.config import settings
 #     return RedirectResponse(url=url)
 
 
-@router.get("/gitlab/login")
-async def login_gitlab():
-    APP_ID, REDIRECT_URI = (
-        settings.GITLAB_CLIENT_ID,
-        "http://localhost:8080/api/auth/callback/gitlab",
-    )
-    url = f"https://gitlab.com/oauth/authorize?client_id={APP_ID}&redirect_uri={REDIRECT_URI}&response_type=code"
-    return RedirectResponse(url=url)
+# @router.get("/gitlab/login")
+# async def login_gitlab():
+#     APP_ID, REDIRECT_URI = (
+#         settings.GITLAB_CLIENT_ID,
+#         "http://localhost:8080/api/auth/callback/gitlab",
+#     )
+#     url = f"https://gitlab.com/oauth/authorize?client_id={APP_ID}&redirect_uri={REDIRECT_URI}&response_type=code"
+#     return RedirectResponse(url=url)
 
 
 @router.get("/api/auth/callback/gitlab")
-async def get_token_from_gitlab(request: Request):
-    code = request.query_params.get("code", None)
-    APP_SECRET, APP_ID = settings.GITLAB_CLIENT_SECRET, settings.GITLAB_CLIENT_ID
+async def get_token_from_gitlab(
+    code: str, client_id: str, client_secret: str, redirect_uri: str
+):
     res = rest_client.post(
         f"https://gitlab.com/oauth/token",
         data={
-            "client_id": APP_ID,
-            "client_secret": APP_SECRET,
+            "client_id": client_id,
+            "client_secret": client_secret,
             "code": code,
             "grant_type": "authorization_code",
-            "redirect_uri": "http://localhost:8080/api/auth/callback/gitlab",
+            "redirect_uri": redirect_uri,
+            # "redirect_uri": "http://localhost:8080/api/auth/callback/gitlab",
         },
     )
     json_res = res.json()
-
     access_token, expires_in = json_res["access_token"], json_res["expires_in"]
     return {"access_token": access_token, "expires_in": expires_in}
 

--- a/app/server/github.py
+++ b/app/server/github.py
@@ -33,6 +33,7 @@ class GitHubOperations:
 
         # Clone the repo to the server
         initialized_repo = Repo.clone_from(self.complete_repo_url, self.local_repo_path)
+
         self.repo_git_path = initialized_repo.git_dir
 
     def push(self) -> None:
@@ -52,6 +53,7 @@ class GitHubOperations:
                 repo.create_remote("origin", target_url)
             origin = repo.remote(name="origin")
             origin.fetch()
+
             origin.push()
         except Exception:
             raise Exception

--- a/app/server/policies.py
+++ b/app/server/policies.py
@@ -35,7 +35,7 @@ async def write_policy(
     policies.append(policy)
 
     # Write the policy to the database after successful push
-    WriteRego(dependencies["token"], rego_rule.github_repo_url).write_to_file(policies)
+    WriteRego(dependencies["token"], rego_rule.repo_url).write_to_file(policies)
 
     database.add_policy(policy, dependencies["login"])
 
@@ -76,9 +76,7 @@ async def modify_policy(
     policies.append(updated_policy)
 
     # Rewrite rego file and update GitHub
-    WriteRego(dependencies["token"], rego_rule["github_repo_url"]).write_to_file(
-        policies
-    )
+    WriteRego(dependencies["token"], rego_rule["repo_url"]).write_to_file(policies)
 
     return {"status": 200, "message": "Updated successfully"}
 
@@ -86,7 +84,7 @@ async def modify_policy(
 @router.delete("/policies/{policy_id}")
 async def remove_policy(
     policy_id: str,
-    github_repo_url: str,
+    repo_url: str,
     database=Depends(get_db),
     dependencies=Depends(TokenBearer()),
 ) -> dict:
@@ -95,11 +93,11 @@ async def remove_policy(
 
     user = dependencies["login"]
     # Remove policy from database
-    database.delete_policy(policy_id, user, github_repo_url)
+    database.delete_policy(policy_id, user, repo_url)
 
     # Update the policy in the rego file
     policies = database.get_policies(owner=user)
-    WriteRego(dependencies["token"], github_repo_url).write_to_file(policies)
+    WriteRego(dependencies["token"], repo_url).write_to_file(policies)
 
     return {"status": 200, "message": "Policy deleted successfully."}
 

--- a/sql/create_database.sql
+++ b/sql/create_database.sql
@@ -1,6 +1,0 @@
-CREATE DATABASE datasource;
-
-CREATE user postgres with password 'postgres';
-
-grant all privileges on database datasource to postgres;
-


### PR DESCRIPTION
[Feature]
`/gitlab/login` route requires cliend_id, and client_secret from gitlab - Users Settings > Applications
the route returns an authorization code, which is redirected to a callback url in our application. verified, and then return an access token to the client.
sample response:
```json
{
  "access_token": "f50e2bf44ff901c2f619cef768f306f2561431413f0362a55fba42ec94fd1c12",
  "expires_in": 7200
}
```