### PR TITLE
[Feature] Added routes to get repos from gitlab

### DIFF
--- a/app/database/datasource_database.py
+++ b/app/database/datasource_database.py
@@ -49,7 +49,6 @@ class Database:
         cur = self.connect()
         cur.execute(query)
         res = cur.fetchone()[0]
-        print("Result from role_exists: ", res)
         return res
 
     def create_tables(self):

--- a/app/server/api.py
+++ b/app/server/api.py
@@ -1,10 +1,15 @@
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 from app.server.auth.authenticate import router as auth_router
-from app.server.policies import router as api_router
-from app.server.user import router as user_router
+from app.server.routes.policies import router as api_router
+from app.server.routes.user import router as user_router
+from app.server.routes.data import router as data_router
 
-app = FastAPI(swagger_ui_parameters={"syntaxHighlight.theme": "obsidian"})
+app = FastAPI(
+    swagger_ui_parameters={"syntaxHighlight.theme": "obsidian"},
+    title="Policy Management API",
+    version="0.1.0",
+)
 
 
 origins = ["*"]
@@ -21,3 +26,4 @@ app.add_middleware(
 app.include_router(auth_router)
 app.include_router(api_router)
 app.include_router(user_router)
+app.include_router(data_router)

--- a/app/server/auth/authenticate.py
+++ b/app/server/auth/authenticate.py
@@ -12,6 +12,16 @@ router = APIRouter()
 from app.config.config import settings
 
 
+@router.get("/gitlab/login")
+async def login_gitlab():
+    APP_ID, REDIRECT_URI = (
+        settings.GITLAB_CLIENT_ID,
+        "http://localhost:8080/api/auth/callback/gitlab",
+    )
+    url = f"https://gitlab.com/oauth/authorize?client_id={APP_ID}&redirect_uri={REDIRECT_URI}&response_type=code"
+    return RedirectResponse(url=url)
+
+
 @router.get("/api/auth/callback/gitlab")
 async def get_token_from_gitlab(
     code: str, client_id: str, client_secret: str, redirect_uri: str

--- a/app/server/auth/authenticate.py
+++ b/app/server/auth/authenticate.py
@@ -3,26 +3,11 @@ import json
 from fastapi import APIRouter
 import requests as rest_client
 from fastapi import APIRouter
-from starlette.responses import RedirectResponse
-from starlette.requests import Request
 
-router = APIRouter()
+router = APIRouter(tags=["Token"])
 
 
-from app.config.config import settings
-
-
-@router.get("/gitlab/login")
-async def login_gitlab():
-    APP_ID, REDIRECT_URI = (
-        settings.GITLAB_CLIENT_ID,
-        "http://localhost:8080/api/auth/callback/gitlab",
-    )
-    url = f"https://gitlab.com/oauth/authorize?client_id={APP_ID}&redirect_uri={REDIRECT_URI}&response_type=code"
-    return RedirectResponse(url=url)
-
-
-@router.get("/api/auth/callback/gitlab")
+@router.get("/gitlab/token")
 async def get_token_from_gitlab(
     code: str, client_id: str, client_secret: str, redirect_uri: str
 ) -> dict:
@@ -34,7 +19,6 @@ async def get_token_from_gitlab(
             "code": code,
             "grant_type": "authorization_code",
             "redirect_uri": redirect_uri,
-            # "redirect_uri": "http://localhost:8080/api/auth/callback/gitlab",
         },
     )
     json_res = res.json()
@@ -42,7 +26,7 @@ async def get_token_from_gitlab(
     return {"access_token": access_token, "expires_in": expires_in}
 
 
-@router.get("/token")
+@router.get("/github/token")
 def get_token_from_github(code: str, client_id: str, client_secret: str) -> dict:
     res = rest_client.post(
         url="https://github.com/login/oauth/access_token",

--- a/app/server/routes/data.py
+++ b/app/server/routes/data.py
@@ -1,0 +1,12 @@
+from fastapi import Depends, HTTPException, APIRouter
+from app.server.auth.authorize import TokenBearer
+
+
+router = APIRouter(tags=["Data Operations"])
+
+from app.database.datasource_database import data
+
+
+@router.get("/data")
+async def get_data(dependencies=Depends(TokenBearer())) -> dict:
+    return {"users": data}

--- a/app/server/routes/policies.py
+++ b/app/server/routes/policies.py
@@ -5,21 +5,21 @@ from app.database.policy import PolicyDatabase, get_db
 from app.schemas.rules import RequestObject, UpdateRequestObject
 from app.server.auth.authorize import TokenBearer
 from app.utils.write_rego import WriteRego
-from app.database.datasource_database import data
+
 
 default_path = settings.BASE_PATH
 
-router = APIRouter()
+router = APIRouter(tags=["Policy Operations"], prefix="/policies")
 
 
-@router.get("/policies")
+@router.get("/")
 async def get_policies(
     database: PolicyDatabase = Depends(get_db), dependencies=Depends(TokenBearer())
 ) -> list:
     return database.get_policies(dependencies["login"])
 
 
-@router.post("/policies/")
+@router.post("/")
 async def write_policy(
     rego_rule: RequestObject,
     database=Depends(get_db),
@@ -42,7 +42,7 @@ async def write_policy(
     return {"status": 200, "message": "Policy created successfully"}
 
 
-@router.get("/policies/{policy_id}")
+@router.get("/{policy_id}")
 async def retrieve_policy(
     policy_id: str, database=Depends(get_db), dependencies=Depends(TokenBearer())
 ) -> dict:
@@ -53,7 +53,7 @@ async def retrieve_policy(
     return stored_policy
 
 
-@router.put("/policies/{policy_id}")
+@router.put("/{policy_id}")
 async def modify_policy(
     policy_id: str,
     rego_rule: UpdateRequestObject,
@@ -81,7 +81,7 @@ async def modify_policy(
     return {"status": 200, "message": "Updated successfully"}
 
 
-@router.delete("/policies/{policy_id}")
+@router.delete("/{policy_id}")
 async def remove_policy(
     policy_id: str,
     repo_url: str,
@@ -100,8 +100,3 @@ async def remove_policy(
     WriteRego(dependencies["token"], repo_url).write_to_file(policies)
 
     return {"status": 200, "message": "Policy deleted successfully."}
-
-
-@router.get("/data")
-async def get_data(dependencies=Depends(TokenBearer())) -> dict:
-    return {"users": data}

--- a/app/server/routes/user.py
+++ b/app/server/routes/user.py
@@ -3,10 +3,10 @@ import requests as r
 
 from app.server.auth.authorize import TokenBearer
 
-router = APIRouter()
+router = APIRouter(tags=["Repo Management"], prefix="/user/repos")
 
 
-@router.get("/user/repos")
+@router.get("/github")
 async def get_public_and_private_repo(
     dependencies=Depends(TokenBearer()),
 ) -> list:
@@ -17,7 +17,7 @@ async def get_public_and_private_repo(
         headers={"Authorization": f"token {dependencies['token']}"},
     ).json()
 
-    return [
+    repos = [
         {
             "name": repo["name"],
             "html_url": repo["html_url"],
@@ -25,9 +25,10 @@ async def get_public_and_private_repo(
         }
         for repo in repos["items"]
     ]
+    return repos
 
 
-@router.get("/user/repos/gitlab")
+@router.get("/gitlab")
 async def get_public_and_private_repo_gitlab(
     dependencies=Depends(TokenBearer()),
 ) -> list:
@@ -38,7 +39,7 @@ async def get_public_and_private_repo_gitlab(
         headers={"Authorization": f"Bearer {dependencies['token']}"},
     ).json()
 
-    return [
+    repos = [
         {
             "name": repo["name"],
             "html_url": repo["web_url"],
@@ -46,3 +47,4 @@ async def get_public_and_private_repo_gitlab(
         }
         for repo in repos
     ]
+    return repos

--- a/app/server/user.py
+++ b/app/server/user.py
@@ -25,3 +25,24 @@ async def get_public_and_private_repo(
         }
         for repo in repos["items"]
     ]
+
+
+@router.get("/user/repos/gitlab")
+async def get_public_and_private_repo_gitlab(
+    dependencies=Depends(TokenBearer()),
+) -> list:
+
+    url = f"https://gitlab.com/api/v4/users/{dependencies['login']}/projects"
+    repos = r.get(
+        url=url,
+        headers={"Authorization": f"Bearer {dependencies['token']}"},
+    ).json()
+
+    return [
+        {
+            "name": repo["name"],
+            "html_url": repo["web_url"],
+            "owner": repo["owner"]["username"],
+        }
+        for repo in repos
+    ]


### PR DESCRIPTION
- Requires user login to gitlab, to generate access token for private repos
- Example response;
```json
[
  {
    "name": "opal-policy-example",
    "html_url": "https://gitlab.com/r-scheele/opal-policy-example",
    "owner": "r-scheele"
  }
]
```
- Updated image on dockerhub