### PR TITLE
[update] - Adjusted data response

### DIFF
--- a/app/server/routes/data.py
+++ b/app/server/routes/data.py
@@ -11,6 +11,9 @@ async def get_data(dependencies=Depends(TokenBearer())) -> dict:
     from app.database.datasource_database import get_database
 
     data = {
-        "sql_query": "SELECT DISTINCT groupname AS value FROM geostore.gs_usergroup;",
+        "sql_query": "SELECT DISTINCT groupname AS value FROM geostore.gs_usergroup",
     }
-    return {"usergroups": get_database().get_data(data["sql_query"])}
+    query = data["sql_query"]
+    res_key = query.split(" ")[-1].replace("gs_", "")
+
+    return {res_key: get_database().get_data(query)}


### PR DESCRIPTION
Response key for data route now dynamic; Both schema name, and table name are extracted from the sql query

```json

{
  "geostore.usergroup": [
    "EDITOR_DPAU",
    "EDITOR_CPQ",
    "VIEWER",
    "everyone",
    "EDITOR_ATAC",
    "TestGeocity",
    "EDITOR_AMBIENTE",
    "GEOCITY_ADMINS",
    "EDITOR_SIZA",
    "ROLE_SYS_GWCS",
    "EDITOR_SITPAU",
    "EDITOR_DBGT",
    "ctr-AltimetriaLineeCTRN-VIEW",
    "ctr-AltimetriaLineeCTRN-EDIT",
    "EDITOR_NIC",
    "ambiente-AsparmRaccoltaFarmaci-EDIT",
    "EDITOR_URBANISTICA",
    "EDITOR_CITTA_PUBBLICA",
    "EDITOR_VINCOLI",
    "EDITOR_COMPLETO"
  ]
}
```
